### PR TITLE
Automatic update of Bogus to 24.3.0

### DIFF
--- a/runracereview/runracereview.csproj
+++ b/runracereview/runracereview.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="23.0.3" />
+    <PackageReference Include="Bogus" Version="24.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="MongoDB.Driver" Version="2.7.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a major update of `Bogus` to `24.3.0` from `23.0.3`
`Bogus 24.3.0` was published at `2018-10-02T17:02:54Z`, 9 days ago

1 project update:
Updated `runracereview/runracereview.csproj` to `Bogus` `24.3.0` from `23.0.3`

[Bogus 24.3.0 on NuGet.org](https://www.nuget.org/packages/Bogus/24.3.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
